### PR TITLE
allow additional arguments for 'pull' and 'up' compose commands

### DIFF
--- a/src/main/kotlin/com/testcompose/annotation/Compose.kt
+++ b/src/main/kotlin/com/testcompose/annotation/Compose.kt
@@ -5,6 +5,8 @@ package com.testcompose.annotation
  *
  * @property id docker compose id, used to attach to running containers
  * @property config path to docker compose config file
+ * @property pullArgs additional arguments to use when issuing 'pull' command
+ * @property upArgs additional arguments to use when issuing 'up' command
  * @property exportPorts list of exposed ports
  * @property waitFor list of log conditions
  */
@@ -13,6 +15,8 @@ package com.testcompose.annotation
 annotation class Compose(
         val id: String = "",
         val config: String = "/docker-compose.yml",
+        val pullArgs: Array<String> = emptyArray(),
+        val upArgs: Array<String> = emptyArray(),
         val exportPorts: Array<Port> = emptyArray(),
         val waitFor: Array<Await> = emptyArray()
 )

--- a/src/main/kotlin/com/testcompose/support/Composition.kt
+++ b/src/main/kotlin/com/testcompose/support/Composition.kt
@@ -9,18 +9,21 @@ class Composition private constructor(
         val external: Boolean
 ) {
 
-    constructor(id: String, configPath: String) : this(DockerCompose(configPath, id), false)
+    constructor(id: String,
+                configPath: String,
+                pullArgs: Array<String>,
+                upArgs: Array<String>) : this(DockerCompose(configPath, id, pullArgs, upArgs), false)
 
     companion object {
 
-        fun create(configPath: String): Composition {
-            val c = Composition(UUID.randomUUID().toString(), configPath)
+        fun create(configPath: String, pullArgs: Array<String>, upArgs: Array<String>): Composition {
+            val c = Composition(UUID.randomUUID().toString(), configPath, pullArgs, upArgs)
             c.start()
             return c
         }
 
         fun attach(configPath: String, id: String): Optional<Composition> {
-            val compose = DockerCompose(configPath, id)
+            val compose = DockerCompose(configPath, id, emptyArray(), emptyArray())
             val lines = compose.ps()
 
             if (lines.size > 2) {

--- a/src/main/kotlin/com/testcompose/support/CompositionRegistry.kt
+++ b/src/main/kotlin/com/testcompose/support/CompositionRegistry.kt
@@ -3,6 +3,7 @@ package com.testcompose.support
 import com.testcompose.annotation.Compose
 import org.junit.platform.commons.util.AnnotationUtils
 import java.util.*
+import java.util.function.Supplier
 import kotlin.collections.HashMap
 
 object CompositionRegistry {
@@ -20,7 +21,8 @@ object CompositionRegistry {
     fun prepare(testClass: Class<*>) {
         findAnnotation(testClass).ifPresent { compose ->
             val composition = compositions.computeIfAbsent(configFullPath(compose)) {
-                Composition.attach(it, compose.id).orElseGet({ Composition.create(it) })
+                Composition.attach(it, compose.id)
+                        .orElseGet { Composition.create(it, compose.pullArgs, compose.upArgs)}
             }
             composition.exportPorts(compose.exportPorts)
             composition.await(compose.waitFor)

--- a/src/main/kotlin/com/testcompose/support/DockerCompose.kt
+++ b/src/main/kotlin/com/testcompose/support/DockerCompose.kt
@@ -2,15 +2,19 @@ package com.testcompose.support
 
 class DockerCompose(
         val configPath: String,
-        val compositionId: String
+        val compositionId: String,
+        val pullArgs: Array<String>,
+        val upArgs: Array<String>
 ) {
 
     fun pull() {
-        DockerComposeCommand("-f", configPath, "-p", compositionId, "pull").waitForComplete()
+        val args = arrayOf("-f", configPath, "-p", compositionId, "pull") + pullArgs
+        DockerComposeCommand(*args).waitForComplete()
     }
 
     fun up() {
-        DockerComposeCommand("-f", configPath, "-p", compositionId, "up", "-d").waitForComplete()
+        val args = arrayOf("-f", configPath, "-p", compositionId, "up", "-d") + upArgs
+        DockerComposeCommand(*args).waitForComplete()
     }
 
     fun down() {


### PR DESCRIPTION
I ran into difficulty working with testcompose in development mode, for the following two reasons.

### Difficulty 1
testcompose issues a docker-compose pull command before starting the containers. This command will always fail (by design) when trying to pull local images built in other projects. One can argue that this can be avoided by building it in the compose file instead of basing it on an image, but that means that the context has to be supplied by relative paths. 
To avoid this, one can actively decide to ignore pull errors (local images as well as any other error) by supplying the --ignore-pull-failures flag.

### Difficulty 2
I would like to run docker-compose up in --compatability mode, allowing me to set hard limits on host resources.